### PR TITLE
Remove psychopy from environments file

### DIFF
--- a/install_macos.sh
+++ b/install_macos.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
 conda env create -n pytaste -f pytaste/conda/environment_macos.yml
+source activate pytaste
+pip install --no-deps psychopy==1.90.1
+source deactivate

--- a/install_win.bat
+++ b/install_win.bat
@@ -1,1 +1,4 @@
 conda env create -n pytaste -f pytaste\conda\environment_win.yml
+activate pytaste
+pip install --no-deps psychopy==1.90.1
+deactivate

--- a/pytaste/conda/environment_macos.yml
+++ b/pytaste/conda/environment_macos.yml
@@ -63,5 +63,4 @@ dependencies:
   - zlib=1.2.11=hf3cbc9b_2
   - pip:
     - json-tricks==3.11.3
-    - psychopy==1.90.1 --install-option="--no-deps"
     - pyglet==1.3.1

--- a/pytaste/conda/environment_win.yml
+++ b/pytaste/conda/environment_win.yml
@@ -62,5 +62,4 @@ dependencies:
   - zlib=1.2.11=hf3cbc9b_2
   - pip:
     - json-tricks==3.11.3
-    - psychopy==1.90.1 --install-option="--no-deps"
     - pyglet==1.3.1


### PR DESCRIPTION
PsychoPy needs to be installed separately so that we can
pass the `--no-deps` parameter to pip. conda environment
files currently do not support that.
See https://github.com/conda/conda/issues/6805